### PR TITLE
Follow symbolic links when searching for files with environment variable to replace.

### DIFF
--- a/files/bin/instateEnvironment.sh
+++ b/files/bin/instateEnvironment.sh
@@ -5,6 +5,11 @@ if [ -z "$1" ]; then
     exit 1;
 fi
 
+if [ ! -f "$1" ]; then
+    (>&2 echo "$1 No such file or directory")
+    exit 2;
+fi
+
 grep -o "{container.env.[a-zA-Z0-9_]\+}" $1 | while read -r GREPRESULT ; do
     # Remove the {container.env.} from the grep result
     ENVNAME=$(echo $GREPRESULT | cut -c16- | rev | cut -c2- | rev)

--- a/files/etc/cont-init.d/01-scan-webfiles-for-environment-variables
+++ b/files/etc/cont-init.d/01-scan-webfiles-for-environment-variables
@@ -1,2 +1,2 @@
 #!/usr/bin/with-contenv sh
-find /var/www -type f -exec /bin/instateEnvironment.sh {} \;
+find /var/www -L -type f -exec /bin/instateEnvironment.sh {} \;

--- a/files/etc/cont-init.d/01-scan-webfiles-for-environment-variables
+++ b/files/etc/cont-init.d/01-scan-webfiles-for-environment-variables
@@ -1,2 +1,2 @@
 #!/usr/bin/with-contenv sh
-find /var/www -L -type f -exec /bin/instateEnvironment.sh {} \;
+find -L /var/www -type f -exec /bin/instateEnvironment.sh {} \;

--- a/test/files/dead_symlink
+++ b/test/files/dead_symlink
@@ -1,0 +1,1 @@
+nonexsistendfile

--- a/test/files/dead_symlink
+++ b/test/files/dead_symlink
@@ -1,1 +1,0 @@
-nonexsistendfile

--- a/test/files/symlink_to_singleline.txt
+++ b/test/files/symlink_to_singleline.txt
@@ -1,0 +1,1 @@
+singleline.txt

--- a/test/files/symlink_to_symlink
+++ b/test/files/symlink_to_symlink
@@ -1,0 +1,1 @@
+symlink_to_singleline.txt

--- a/test/symlinks.bats
+++ b/test/symlinks.bats
@@ -31,7 +31,5 @@ setup () {
 @test "Replacing a dead_symlink" {
     FILE=$BATS_RUN_DIR/files/dead_symlink
     run /bin/sh $BATS_BINARY_DIR/instateEnvironment.sh $FILE
-    assert_success "Replacing {container.env.BATS_VARIABLE} with $BATS_VARIABLE in $FILE"
-    assert_file_refute_contains $FILE {container.env.BATS_VARIABLE}
-    assert_file_contains $FILE $BATS_VARIABLE
+    assert_failure
 }

--- a/test/symlinks.bats
+++ b/test/symlinks.bats
@@ -30,6 +30,14 @@ setup () {
 
 @test "Replacing a dead_symlink" {
     FILE=$BATS_RUN_DIR/files/dead_symlink
+    ln -s $BATS_RUN_DIR/files/does_not_exists $FILE
+    run /bin/sh $BATS_BINARY_DIR/instateEnvironment.sh $FILE
+    assert_failure
+    rm -rf $FILE
+}
+
+@test "Replacing a non existing file" {
+    FILE=$BATS_RUN_DIR/files/does_not_exist
     run /bin/sh $BATS_BINARY_DIR/instateEnvironment.sh $FILE
     assert_failure
 }

--- a/test/symlinks.bats
+++ b/test/symlinks.bats
@@ -1,0 +1,37 @@
+#/usr/bin/env bats
+
+load helpers/environment
+load helpers/assert_file
+load helpers/assertions/all
+
+setup () {
+    # @todo: fix test for [] since it breaks the grep assertion
+    
+    __setup_environment
+    __create_run_directory
+    export BATS_VARIABLE='nstapelbroek-was-here'
+}
+
+@test "Replacing a normal symlink" {
+    FILE=$BATS_RUN_DIR/files/symlink_to_singleline.txt
+    run /bin/sh $BATS_BINARY_DIR/instateEnvironment.sh $FILE
+    assert_success "Replacing {container.env.BATS_VARIABLE} with $BATS_VARIABLE in $FILE"
+    assert_file_refute_contains $FILE {container.env.BATS_VARIABLE}
+    assert_file_contains $FILE $BATS_VARIABLE
+}
+
+@test "Replacing a symlink to a symlink" {
+    FILE=$BATS_RUN_DIR/files/symlink_to_symlink
+    run /bin/sh $BATS_BINARY_DIR/instateEnvironment.sh $FILE
+    assert_success "Replacing {container.env.BATS_VARIABLE} with $BATS_VARIABLE in $FILE"
+    assert_file_refute_contains $FILE {container.env.BATS_VARIABLE}
+    assert_file_contains $FILE $BATS_VARIABLE
+}
+
+@test "Replacing a dead_symlink" {
+    FILE=$BATS_RUN_DIR/files/dead_symlink
+    run /bin/sh $BATS_BINARY_DIR/instateEnvironment.sh $FILE
+    assert_success "Replacing {container.env.BATS_VARIABLE} with $BATS_VARIABLE in $FILE"
+    assert_file_refute_contains $FILE {container.env.BATS_VARIABLE}
+    assert_file_contains $FILE $BATS_VARIABLE
+}


### PR DESCRIPTION
# What

Follow symbolic links when searching for files with environment variable to replace.

# Why

I'm building a nuxt.js project, which is working quite nice. But every time you build the static assets, it removes the `dist` folder, breaking the docker mount for the dist folder. To work around that, I created the following:

```
FROM nstapelbroek/static-webserver:latest

COPY . /opt/Nawcast/main

RUN rm -rf /var/www && ln -s /opt/Nawcast/main/dist /var/www
```

Now the docker mount wont break when developing locally, but the environment variables weren't replaced anymore on production builds. I figured that is because the find script can't follow symbolic links. This was easily fixed with `-L` however.

Probably useful for others as wel!